### PR TITLE
v4.4.8 On-demand garbage collection

### DIFF
--- a/Locale/en.lua
+++ b/Locale/en.lua
@@ -270,8 +270,9 @@ L["UnlockCommand"] = "unlock";
 L["ResetCommand"] = "reset";
 L["ResetTotalsCommand"] = "reset totals";
 L["LockToggleCommand"] = "lock toggle";
+L["CleanUpCommand"] = "cleanup";
 
-L["CommandUsage"] = "usage: /ca "..L.Options.." | "..L.SaveCommand.." | "..L.LoadCommand.." | "..L.ToggleCommand.." | "..L.ShowCommand.." | "..L.HideCommand.." | "..L.LockToggleCommand.." | "..L.LockCommand.." | "..L.UnlockCommand.." | "..L.ResetCommand.." | "..L.ResetTotalsCommand;
+L["CommandUsage"] = "usage: /ca "..L.Options.." | "..L.SaveCommand.." | "..L.LoadCommand.." | "..L.ToggleCommand.." | "..L.ShowCommand.." | "..L.HideCommand.." | "..L.LockToggleCommand.." | "..L.LockCommand.." | "..L.UnlockCommand.." | "..L.ResetCommand.." | "..L.ResetTotalsCommand.." | "..L.CleanUpCommand;
 -- Value/Date Formatting
 
 L["Thousand"] = "K";
@@ -389,6 +390,7 @@ L["RestoreTab"] = "Restore Tab";
 L["CloseTab"] = "Close Tab";
 
 L["ResetTotals"] = "Reset Totals";
+L["CleanUp"] = "Garbage Collect";
 
 -- Chat Menu (indexed by {command, channel name})
 

--- a/Utils/Commands.lua
+++ b/Utils/Commands.lua
@@ -70,6 +70,12 @@ function UpdateCommand:Execute(cmd, args)
       combatData:ResetTotals(true);
       return;
     end
+	
+	if ( string.find( args, L.CleanUpCommand ) == 1 ) then
+      combatData:ResetTotals(true);
+	  collectgarbage();
+      return;
+    end
     
     if ( string.find( args, L.ResetCommand ) == 1 ) then
       if (not player:IsInCombat()) then


### PR DESCRIPTION
Added a console command; /ca cleanup; to do on-demand garbage collection. After running CA for extended periods of time, such as 20-30K attacks, I find the actual game starts to lag. Previously I would unload vitals and reload CA which would appear to clear up the lag. My cleanup command first resets totals, then does a collectgarbage(). I also tried to add a right-click context menu option, as shown in en.lua, but I think I need to do more.