### PR TITLE
Implement event type Enums and let Benefits be sent to buffbars

### DIFF
--- a/Locale/de.lua
+++ b/Locale/de.lua
@@ -592,7 +592,7 @@ L["Parse"] = function(line)
 		if (moralePower == 2) then return nil end
 		
 		-- Update
-		return 1,initiatorName,targetName,skillName,amount,avoidType,critType,dmgType;
+		return event_type.DMG_DEALT,initiatorName,targetName,skillName,amount,avoidType,critType,dmgType;
 	end
 	
 	-- 2) Heal line --
@@ -615,7 +615,7 @@ L["Parse"] = function(line)
 		amount = string.gsub(amount,",","")+0;
 		
 		-- Update
-		return (moralePower == 2 and 4 or 3),initiatorName,targetName,skillName,amount,critType;
+		return (moralePower == 2 and event_type.POWER_RESTORE or event_type.HEAL),initiatorName,targetName,skillName,amount,critType;
 	end
 	
 	-- 2.2) Self Heal
@@ -630,7 +630,7 @@ L["Parse"] = function(line)
 		critType = critType == "kritische " and 2 or
 				   critType == "zerst\195\182rerische " and 3 or 1;
 		
-		return (moralPower == 2 and 4 or 3), initiatorName, initiatorName, skillName, amount, critType;
+		return (moralPower == 2 and event_type.POWER_RESTORE or event_type.HEAL), initiatorName, initiatorName, skillName, amount, critType;
 	end
 	
 	-- 3) Buff line --
@@ -640,7 +640,7 @@ L["Parse"] = function(line)
 		initiatorName = TrimArticles(initiatorName);
 		targetName = TrimArticles(targetName);
 		-- Update
-		return 17,initiatorName,targetName,skillName;
+		return event_type.BENEFIT,initiatorName,targetName,skillName;
 	end
 	
 	-- 4) Avoid line --
@@ -661,7 +661,7 @@ L["Parse"] = function(line)
 				string.match(avoidType,"Immunit\195\164t") and 3 or 1;
 		-- Sanity check: must have avoided in some manner
 		if (avoidType == 1) then return nil end
-		return 1,initiatorName,targetName,skillName,0,avoidType,1,10;
+		return event_type.DMG_DEALT,initiatorName,targetName,skillName,0,avoidType,1,10;
 	end
 		
 	-- miss
@@ -673,7 +673,7 @@ L["Parse"] = function(line)
 		skillName = string.gsub(skillName, "\"", "");
 		local avoidType = 2;
 		-- Update
-		return 1,initiatorName,targetName,skillName,0,avoidType,1,10;
+		return event_type.DMG_DEALT,initiatorName,targetName,skillName,0,avoidType,1,10;
 	end
 		
 	
@@ -703,10 +703,10 @@ L["Parse"] = function(line)
 				dmgType == "\"Ork-Waffe\"" and 11 or
 				dmgType == "\"Hass\"" and 12 or 13;
 			-- a dmg reflect
-			return 1,initiatorName,targetName,skillName,amount,1,1,dmgType;
+			return event_type.DMG_DEALT,initiatorName,targetName,skillName,amount,1,1,dmgType;
 		else
 			-- a heal reflect
-			return 3,initiatorName,targetName,skillName,amount,1;
+			return event_type.HEAL,initiatorName,targetName,skillName,amount,1;
 		end
 	end
 	
@@ -715,7 +715,7 @@ L["Parse"] = function(line)
 	if (amount ~= nil) then
 		amount = string.gsub(amount,",","")+0;
 		-- the only information we can extract directly is the target and amount
-		return 14,nil,player.name,nil,amount;
+		return event_type.TEMP_MORALE_LOST,nil,player.name,nil,amount;
 	end
 	
 	-- 7) Combat State Break notice (as of 4.1.0)
@@ -725,7 +725,7 @@ L["Parse"] = function(line)
 	if (targetName ~= nil) then
 		targetName = TrimArticles(targetName);
 		-- the only information we can extract directly is the target name
-		return 16,nil,targetName,nil;
+		return event_type.CC_BROKEN,nil,targetName,nil;
 	end
 	
 	-- 7b) Daze broken
@@ -733,7 +733,7 @@ L["Parse"] = function(line)
 	if (targetName ~= nil) then
 		targetName = TrimArticles(targetName);
 		-- the only information we can extract directly is the target name
-		return 16,nil,targetName,nil;
+		return event_type.CC_BROKEN,nil,targetName,nil;
 	end
 	
 	-- 7c) Fear broken
@@ -741,7 +741,7 @@ L["Parse"] = function(line)
 	if(targetName ~= nil) then
 		targetName = TrimArticles(targetName);
 		-- the only information we can extract directly is the target name
-		return 16,nil,targetName,nil;
+		return event_type.CC_BROKEN,nil,targetName,nil;
 	end
 		
 	
@@ -752,7 +752,7 @@ L["Parse"] = function(line)
 		targetName = TrimArticles(targetName);
 		
 		-- Update
-		return 7,initiatorName,targetName;
+		return event_type.INTERRUPT,initiatorName,targetName;
 	end
 	
 	-- 9) Dispell line (corruption removal) --
@@ -762,7 +762,7 @@ L["Parse"] = function(line)
 		-- NB: Currently ignore corruption name
 		
 		-- Update
-		return 8,player.name,targetName;
+		return event_type.CORRUPTION,player.name,targetName;
 	end
 	
 	-- 10) Defeat lines ---
@@ -773,7 +773,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 		initiatorName = TrimArticles(initiatorName);
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10b) Defeat line 2 (mob died)
@@ -782,7 +782,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 		initiatorName = TrimArticles(initiatorName);
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10c) Defeat line 3 (a player was killed or died)
@@ -791,7 +791,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 		initiatorName = TrimArticles(initiatorName);
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10d) Defeat line 4 (you were killed)
@@ -799,7 +799,7 @@ L["Parse"] = function(line)
 
 	if (match ~= nil) then
 		-- Update
-		return 9,player.name;
+		return event_type.DEATH,player.name;
 	end
 	
 	-- 10e) Defeat line 5 (you died)
@@ -807,7 +807,7 @@ L["Parse"] = function(line)
 
 	if (match ~= nil) then
 		-- Update
-		return 9,player.name;
+		return event_type.DEATH,player.name;
 	end
 	
 	-- 11) Revive lines --
@@ -818,7 +818,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 		initiatorName = TrimArticles(initiatorName);
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- 11b) Revive line 2 (player succumbed)
@@ -827,7 +827,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 	  initiatorName = TrimArticles(initiatorName);
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- 11c) Revive line 3 (you were revived)
@@ -835,7 +835,7 @@ L["Parse"] = function(line)
 	
 	if (match ~= nil) then
 		-- Update
-	  return 10,player.name;
+	  return event_type.REVIVE,player.name;
 	end
 	
 	-- 11d) Revive line 4 (you succumbed)
@@ -843,7 +843,7 @@ L["Parse"] = function(line)
 	
 	if (match ~= nil) then
 		-- Update
-	  return 10,player.name;
+	  return event_type.REVIVE,player.name;
 	end
 	
 	-- if we reach here, we were unable to parse the line

--- a/Locale/en.lua
+++ b/Locale/en.lua
@@ -588,7 +588,7 @@ L["Parse"] = function(line)
 		if (moralePower == 2) then return nil end
 		
 		-- Update
-		return 1,initiatorName,targetName,skillName,amount,avoidType,critType,dmgType;
+		return event_type.DMG_DEALT,initiatorName,targetName,skillName,amount,avoidType,critType,dmgType;
 	end
 	
 	-- 2) Heal line --
@@ -627,7 +627,7 @@ L["Parse"] = function(line)
 		end
 		
 		-- Update
-		return (moralePower == 2 and 4 or 3),initiatorName,targetName,skillName,amount,critType;
+		return (moralePower == 2 and event_type.POWER_RESTORE or event_type.HEAL),initiatorName,targetName,skillName,amount,critType;
 	end
 	
 	-- 3) Buff line --
@@ -639,7 +639,7 @@ L["Parse"] = function(line)
 		targetName = string.gsub(targetName,"^[Tt]he ","");
 		
 		-- Update
-		return 17,initiatorName,targetName,skillName;
+		return event_type.BENEFIT,initiatorName,targetName,skillName;
 	end
 	
 	-- 4) Avoid line --
@@ -678,7 +678,7 @@ L["Parse"] = function(line)
 		if (avoidType == 1) then return nil end
 		
 		-- Update
-		return 1,initiatorName,targetName,skillName,0,avoidType,1,13;
+		return event_type.DMG_DEALT,initiatorName,targetName,skillName,0,avoidType,1,13;
 	end
 	
 	-- 5) Reflect line --
@@ -709,11 +709,11 @@ L["Parse"] = function(line)
 				dmgType == "Fell-wrought " and 12 or 13;
 						
 			-- Update
-			return 1,initiatorName,targetName,skillName,amount,1,1,dmgType;
+			return event_type.DMG_DEALT,initiatorName,targetName,skillName,amount,1,1,dmgType;
 		-- a heal reflect
 		else
 			-- Update
-			return 3,initiatorName,targetName,skillName,amount,1;
+			return event_type.HEAL,initiatorName,targetName,skillName,amount,1;
 		end
 	end
 	
@@ -723,7 +723,7 @@ L["Parse"] = function(line)
 		amount = string.gsub(amount,",","")+0;
 		
 		-- the only information we can extract directly is the target and amount
-		return 14,nil,player.name,nil,amount;
+		return event_type.TEMP_MORALE_LOST,nil,player.name,nil,amount;
 	end
 	
 	-- 7) Combat State Break notice (as of 4.1.0)
@@ -734,7 +734,7 @@ L["Parse"] = function(line)
 		targetName = string.gsub(targetName,"^[Tt]he ","");
 		
 		-- the only information we can extract directly is the target name
-		return 16,nil,targetName,nil;
+		return event_type.CC_BROKEN,nil,targetName,nil;
 	end
 	
 	-- 7b) Daze broken
@@ -743,7 +743,7 @@ L["Parse"] = function(line)
 		targetName = string.gsub(targetName,"^[Tt]he ","");
 		
 		-- the only information we can extract directly is the target name
-		return 16,nil,targetName,nil;
+		return event_type.CC_BROKEN,nil,targetName,nil;
 	end
 	
 	-- 7c) Fear broken (TODO: Check)
@@ -752,7 +752,7 @@ L["Parse"] = function(line)
 		targetName = string.gsub(targetName,"^[Tt]he ","");
 		
 		-- the only information we can extract directly is the target name
-		return 16,nil,targetName,nil;
+		return event_type.CC_BROKEN,nil,targetName,nil;
 	end
 	
 	-- 8) Interrupt line --
@@ -764,7 +764,7 @@ L["Parse"] = function(line)
 		targetName = string.gsub(targetName,"^[Tt]he ","");
 		
 		-- Update
-		return 7,initiatorName,targetName;
+		return event_type.INTERRUPT,initiatorName,targetName;
 	end
 	
 	-- 9) Dispell line (corruption removal) --
@@ -778,7 +778,7 @@ L["Parse"] = function(line)
 		-- NB: Currently ignore corruption name
 		
 		-- Update
-		return 8,initiatorName,targetName;
+		return event_type.CORRUPTION,initiatorName,targetName;
 	end
 	
 	-- 10) Defeat lines ---
@@ -790,7 +790,7 @@ L["Parse"] = function(line)
 		initiatorName = string.gsub(initiatorName,"^[Tt]he ","");
 		
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10b) Defeat line 2 (mob died)
@@ -800,7 +800,7 @@ L["Parse"] = function(line)
 		initiatorName = string.gsub(initiatorName,"^[Tt]he ","");
 		
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10c) Defeat line 3 (a player was killed or died)
@@ -810,7 +810,7 @@ L["Parse"] = function(line)
 		initiatorName = string.gsub(initiatorName,"^[Tt]he ","");
 		
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10d) Defeat line 4 (you were killed)
@@ -820,7 +820,7 @@ L["Parse"] = function(line)
 		initiatorName = player.name;
 		
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10e) Defeat line 5 (you died)
@@ -830,7 +830,7 @@ L["Parse"] = function(line)
 		initiatorName = player.name;
 		
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 10f) Defeat line 6 (you killed a mob)
@@ -840,7 +840,7 @@ L["Parse"] = function(line)
 		initiatorName = string.gsub(initiatorName,"^[Tt]he ","");
 		
 		-- Update
-		return 9,initiatorName;
+		return event_type.DEATH,initiatorName;
 	end
 	
 	-- 11) Revive lines --
@@ -852,7 +852,7 @@ L["Parse"] = function(line)
 	  initiatorName = string.gsub(initiatorName,"^[Tt]he ","");
 	  
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- 11b) Revive line 2 (player succumbed)
@@ -862,7 +862,7 @@ L["Parse"] = function(line)
 	  initiatorName = string.gsub(initiatorName,"^[Tt]he ","");
 	  
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- 11c) Revive line 3 (you were revived)
@@ -872,7 +872,7 @@ L["Parse"] = function(line)
 	  initiatorName = player.name;
 	  
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- 11d) Revive line 4 (you succumbed)
@@ -882,7 +882,7 @@ L["Parse"] = function(line)
 	  initiatorName = player.name;
 	  
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- if we reach here, we were unable to parse the line

--- a/Locale/fr.lua
+++ b/Locale/fr.lua
@@ -612,7 +612,7 @@ L["Parse"] = function(line)
 		if (moralePower == 2) then return nil end
 		
 		-- Update
-		return 1,trim_articles(initiatorName),trim_articles(targetName),skillName,amount,avoidType,critType,dmgType;
+		return event_type.DMG_DEALT,trim_articles(initiatorName),trim_articles(targetName),skillName,amount,avoidType,critType,dmgType;
 	end
 	
 	-- 2) Heal line --
@@ -648,7 +648,7 @@ L["Parse"] = function(line)
 		morale_power = (morale_power == 'Moral' and 1 or (morale_power == 'Puissance' and 2 or 3));
 		dmg_amount = (morale_power == 3 and 0 or string.gsub(dmg_amount, ',', '') + 0);
 
-		return (morale_power == 2 and 4 or 3), trim_articles(initiator_name), trim_articles(target_name), skill_name, dmg_amount, crit_type;
+		return (morale_power == 2 and event_type.POWER_RESTORE or event_type.HEAL), trim_articles(initiator_name), trim_articles(target_name), skill_name, dmg_amount, crit_type;
 	end
 	
 	-- 3) Buff line --
@@ -659,7 +659,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 		
 		-- Update
-		return 17,trim_articles(initiatorName),trim_articles(targetName),skillName;
+		return event_type.BENEFIT,trim_articles(initiatorName),trim_articles(targetName),skillName;
 	end
 	
 	-- 4) Avoid line --
@@ -682,7 +682,7 @@ L["Parse"] = function(line)
 		if (avoid_type == 1) then
 			return nil;
 		end
-		return 1, trim_articles(initiator_name), trim_articles(target_name), skill_name, 0, avoid_Type, 1, 10;
+		return event_type.DMG_DEALT, trim_articles(initiator_name), trim_articles(target_name), skill_name, 0, avoid_Type, 1, 10;
 	end
 	
 	-- 4b) miss or deflect (deflect added in v4.2.2)
@@ -692,7 +692,7 @@ L["Parse"] = function(line)
 	if (initiator_name ~= nil) then
 		avoid_type = 2;
 
-		return 1, trim_articles(initiator_name), trim_articles(target_name), skill_name, 0, avoid_type, 1, 10;
+		return event_type.DMG_DEALT, trim_articles(initiator_name), trim_articles(target_name), skill_name, 0, avoid_type, 1, 10;
 	end
 	
 	-- 5) Reflect line --
@@ -720,11 +720,11 @@ L["Parse"] = function(line)
 				dmgType == "Nain d'antan" and 10 or 11;
 						
 			-- Update
-			return 1,trim_articles(initiatorName),trim_articles(targetName),skillName,amount,1,1,dmgType;
+			return event_type.DMG_DEALT,trim_articles(initiatorName),trim_articles(targetName),skillName,amount,1,1,dmgType;
 		-- a heal reflect
 		else
 			-- Update
-			return 3,trim_articles(initiatorName),trim_articles(targetName),skillName,amount,1;
+			return event_type.HEAL,trim_articles(initiatorName),trim_articles(targetName),skillName,amount,1;
 		end
 	end
 	
@@ -734,7 +734,7 @@ L["Parse"] = function(line)
 		amount = string.gsub(amount,",","")+0;
 		
 		-- the only information we can extract directly is the target and amount
-		return 14,nil,trim_articles(player.name),nil,amount;
+		return event_type.TEMP_MORALE_LOST,nil,trim_articles(player.name),nil,amount;
 	end
 	
 	-- 7) Combat State Break notice (as of 4.1.0)
@@ -750,10 +750,10 @@ L["Parse"] = function(line)
 		target_name = (target_name == "" and player.name or target_name);
 
 		if (printDebug) then
-  		Turbine.Shell.WriteLine("root_broken", line, "ini_name: " .. initiator_name .. " tgt_name: " .. target_name);
+  			Turbine.Shell.WriteLine("root_broken", line, "ini_name: " .. initiator_name .. " tgt_name: " .. target_name);
 		end
 
-		return 16, nil, trim_articles(target_name), nil;
+		return event_type.CC_BROKEN, nil, trim_articles(target_name), nil;
 	end
 	
 	-- 7b) Daze broken
@@ -770,7 +770,7 @@ L["Parse"] = function(line)
 		  Turbine.Shell.WriteLine("daze_broken", line, "ini_name: " .. initiator_name .. " tgt_name: " .. target_name);
 		end
 
-		return 16, nil, target_name, nil;
+		return event_type.CC_BROKEN, nil, target_name, nil;
 	end
 	
 	-- 8) Interrupt line --
@@ -778,7 +778,7 @@ L["Parse"] = function(line)
 	local target_name, initiator_name = string.match(line, "^(.*) a été interrompu par (.*)!$");
 
 	if (target_name ~= nil) then
-		return 7, trim_articles(initiator_name), trim_articles(target_name);
+		return event_type.INTERRUPT, trim_articles(initiator_name), trim_articles(target_name);
 	end
 	
 	-- 9) Dispell line (corruption removal) --
@@ -790,7 +790,7 @@ L["Parse"] = function(line)
 		-- NB: Currently ignore corruption name
 		
 		-- Update
-		return 8, trim_articles(initiator_name), trim_articles(target_name);
+		return event_type.CORRUPTION, trim_articles(initiator_name), trim_articles(target_name);
 	end
 	
 	-- 10) Defeat lines ---
@@ -801,7 +801,7 @@ L["Parse"] = function(line)
 	if (initiator_name ~= nil) then
 
 	-- Update
-		return 9, trim_articles(initiator_name);
+		return event_type.DEATH, trim_articles(initiator_name);
 	end
 
 	-- 10b) Defeat line 2 (mob died)
@@ -810,7 +810,7 @@ L["Parse"] = function(line)
 	if (initiator_name ~= nil) then
 		
 		-- Update
-		return 9, trim_articles(initiator_name);
+		return event_type.DEATH, trim_articles(initiator_name);
 	end
 
 	-- 10c) Defeat line 3 (a player was killed or died)
@@ -819,7 +819,7 @@ L["Parse"] = function(line)
 	if (initiator_name ~= nil) then
 		
 		-- Update
-		return 9, trim_articles(initiator_name);
+		return event_type.DEATH, trim_articles(initiator_name);
 	end
 
 	-- 10d) Defeat line 4 (you were killed)
@@ -828,7 +828,7 @@ L["Parse"] = function(line)
 	if (match ~= nil) then
 		
 		-- Update
-		return 9, trim_articles(player.name);
+		return event_type.DEATH, trim_articles(player.name);
 	end
 
 	-- 10e) Defeat line 5 (you died)
@@ -837,7 +837,7 @@ L["Parse"] = function(line)
 	if (match ~= nil) then
 		
 		-- Update
-		return 9, trim_articles(player.name);
+		return event_type.DEATH, trim_articles(player.name);
 	end	
 	-- 10f) Defeat line 6 (you killed a mob)
 	local initiatorName = string.match(line,"^Votre coup puissant a vaincu (.*)%.$");
@@ -845,7 +845,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 		
 		-- Update
-		return 9,trim_articles(initiatorName);
+		return event_type.DEATH,trim_articles(initiatorName);
 	end
 	
 	-- 11) Revive lines --
@@ -856,7 +856,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 	  
 		-- Update
-	  return 10,trim_articles(initiatorName);
+	  return event_type.REVIVE,trim_articles(initiatorName);
 	end
 	
 	-- 11b) Revive line 2 (player succumbed)
@@ -865,7 +865,7 @@ L["Parse"] = function(line)
 	if (initiatorName ~= nil) then
 	  
 		-- Update
-	  return 10,trim_articles(initiatorName);
+	  return event_type.REVIVE,trim_articles(initiatorName);
 	end
 	
 	-- 11c) Revive line 3 (you were revived)
@@ -875,7 +875,7 @@ L["Parse"] = function(line)
 	  initiatorName = player.name;
 	  
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- 11d) Revive line 4 (you succumbed)
@@ -885,7 +885,7 @@ L["Parse"] = function(line)
 	  initiatorName = player.name;
 	  
 		-- Update
-	  return 10,initiatorName;
+	  return event_type.REVIVE,initiatorName;
 	end
 	
 	-- if we reach here, we were unable to parse the line

--- a/Parser/Parser.lua
+++ b/Parser/Parser.lua
@@ -30,9 +30,9 @@ Misc.AddCallback(Turbine.Chat,"Received",function(sender, args)
       
       -- Check for self damage
 			if (targetName == player.name) then
-
 		        -- NB: currently just ignore self interrupts
 		        if (updateType == event_type.INTERRUPT) then return end
+
 
 				if (printDebug) then
 					Turbine.Shell.WriteLine("self damage > "..tostring(updateType == event_type.DMG_DEALT and event_type.DMG_TAKEN or event_type.MOB_INTERRUPT)..","..tostring(timestamp)..","..tostring(initiatorName)..","..tostring(targetName)..","..tostring(skillName)..","..tostring(var1)..","..tostring(var2)..","..tostring(var3)..","..tostring(var4));
@@ -42,6 +42,7 @@ Misc.AddCallback(Turbine.Chat,"Received",function(sender, args)
 	        
 			-- Check if the skill used is a tracked Debuff (if it wasn't avoided)
 			elseif (updateType == event_type.DMG_DEALT and (var2 == 1 or (var2 > 7 and var2 < 11))) then
+
 		        if (debuffApplications[skillName] ~= nil) then
 		          for debuffName, skillInfo in pairs(debuffApplications[skillName]) do
 		            InitiateDebuff(timestamp,var3,initiatorName,targetName,debuffName,skillInfo,true);
@@ -138,10 +139,16 @@ Misc.AddCallback(Turbine.Chat,"Received",function(sender, args)
 			var1 = 0; -- a zero heal
 			var2 = 1; -- a hit
 		end
-		
+		-- If player wanted to track the benefit as a debuff, initiate
+		if (debuffApplications[skillName] ~= nil) then
+          for debuffName, skillInfo in pairs(debuffApplications[skillName]) do
+            InitiateDebuff(timestamp,var3,initiatorName,targetName,debuffName,skillInfo,true);
+          end
+        end
+
 		-- Also check if the skill used was a tracked morale bubble
 		CheckMoraleBubble(timestamp,targetName,skillName,initiatorName,false);
-		
+
 		-- If this benefit was not tracked, do nothing
 		if (updateType == event_type.BENEFIT) then return end
 		
@@ -203,13 +210,13 @@ end
 function _G.ApplyDebuff(timestamp,effectInfo)
 	local initiatorName = effectInfo[1];
 	local targetName = effectInfo[2];
-  local skillName = effectInfo[3];
+	local skillName = effectInfo[3];
 	local applicationInfo = effectInfo[4]; -- crits only, duration, delay
-  local isDebuff = effectInfo[5];
-  local skillInfo = (isDebuff and debuffs[skillName] or cc[skillName]); -- skill type, removal only, overwrites, icon, conflicts, buff effects
-  timestamp = math.max((combatData.currentEncounter and combatData.currentEncounter.orderedMobs[1].gameStartTime or Turbine.Engine.GetGameTime()), timestamp + (applicationInfo.delay or 0));
+	local isDebuff = effectInfo[5];
+  	local skillInfo = (isDebuff and debuffs[skillName] or cc[skillName]); -- skill type, removal only, overwrites, icon, conflicts, buff effects
+  	timestamp = math.max((combatData.currentEncounter and combatData.currentEncounter.orderedMobs[1].gameStartTime or Turbine.Engine.GetGameTime()), timestamp + (applicationInfo.delay or 0));
   
-  -- 1) ensure that debuffs aren't applied if a conflicting debuff is on the mob
+  	-- 1) ensure that debuffs aren't applied if a conflicting debuff is on the mob
 	if (not skillInfo.removalOnly and skillInfo.conflicts ~= nil) then
     -- debuff
     if (isDebuff) then

--- a/Players/Player.lua
+++ b/Players/Player.lua
@@ -63,7 +63,7 @@ end
 Misc.AddCallback(player,"InCombatChanged",function()
 	local inCombat = player:IsInCombat();
 	-- send combat state change update
-	combatData:Update(inCombat and 11 or 12,Turbine.Engine.GetGameTime(),player.name);
+	combatData:Update(inCombat and event_type.COMBAT_START or event_type.COMBAT_END,Turbine.Engine.GetGameTime(),player.name);
 	-- if we just exited combat, clear all pending & running debuffs
 	if (not inCombat) then
     pendingDebuffs:Clear();

--- a/Utils/Enums.lua
+++ b/Utils/Enums.lua
@@ -1,0 +1,27 @@
+--[[
+
+This file is used to provide enums to the entire codebase.
+
+Any number of enums can be put here to make other code more readable.
+
+]]--
+
+_G.event_type = {
+	DMG_DEALT = 1,
+	DMG_TAKEN = 2,
+	HEAL = 3,
+	POWER_RESTORE = 4,
+	DEBUFF_APPLIED = 5,
+	BUFF_APPLIED = 6,
+	INTERRUPT = 7,
+	CORRUPTION = 8,
+	DEATH = 9,
+	REVIVE = 10,
+	COMBAT_START = 11,
+	COMBAT_END = 12,
+	MOB_INTERRUPT = 13,
+	TEMP_MORALE_LOST = 14,
+	TEMP_MORALE_NOT_WASTED = 15,
+	CC_BROKEN = 16,
+	BENEFIT = 17,
+}

--- a/Utils/__init__.lua
+++ b/Utils/__init__.lua
@@ -25,6 +25,7 @@ import "CombatAnalysis.Utils.OrderedFileList"
 import "CombatAnalysis.Utils.Settings"
 import "CombatAnalysis.Utils.DataStorage"
 import "CombatAnalysis.Utils.Misc"
+import "CombatAnalysis.Utils.Enums"
 
 import "CombatAnalysis.Utils.Commands"
 import "CombatAnalysis.Utils.KeyManager"


### PR DESCRIPTION
First time contributor here. I meant to send these as 2 separate PRs, let me know if you want them split.

I migrated usage of ints to something more like an enum just for readability while I was working on my main feature: letting benefits get sent to buffbars.
Admittedly this isn't perfect because when I apply a benefit to another it's not a mob debuff, it's a friend's buff that i'm trying to track. However it does work. I can track using BuffBars how long each target has DNF set on it (my main use case). 

Open to doing more work, hope this is helpful!